### PR TITLE
Implement Heightmap stack for terrain

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -48,8 +48,8 @@ ProceduralPlanetLOD aims to create a fully procedural planet that dynamically ad
 - **FaceChunk** manages the geometry for a specific quadtree patch and handles LOD transitions.
 
 ### Terrain Generation
-- **NoiseGenerator** provides deterministic elevation values via seeded FastNoiseLite.
-- Optional GPU noise or warping can create more variety.
+- **HeightmapStack** combines modular modifiers (FBM noise, domain warp, terracing, etc.) using FastNoiseLite for deterministic results.
+- Each modifier can be toggled or extended for biome control and GPU-based implementations.
 
 ### Shader Structure
 - **TerrainShader** colors terrain based on height or biome data.
@@ -59,7 +59,7 @@ ProceduralPlanetLOD aims to create a fully procedural planet that dynamically ad
 1. **Base Infrastructure**: Project setup with ES modules and Three.js rendering.
 2. **Cube-Sphere Geometry**: Implement GeometryBuilder with cube-to-sphere mapping.
 3. **Quadtree LOD**: Build FaceChunk and ChunkLODController to manage dynamic LOD.
-4. **Noise Integration**: Integrate FastNoiseLite for deterministic terrain heights.
+4. **Noise Integration**: Use HeightmapStack with FastNoiseLite-based modifiers for deterministic terrain heights.
 5. **Asynchronous Chunk Generation**: Offload heavy geometry builds using `requestIdleCallback` or Web Workers.
 6. **Shaders and Materials**: Provide extensible shader modules for terrain and water.
 7. **Optional Enhancements**: Support biomes, atmosphere scattering, water simulation, and export functionality.

--- a/src/FaceChunk.js
+++ b/src/FaceChunk.js
@@ -9,6 +9,10 @@ export default class FaceChunk {
     this.children = [];
   }
 
+  getVertexHeight(x, y, z) {
+    return this.builder.getVertexHeight(x, y, z);
+  }
+
   createMesh(material) {
     const geometry = this.builder.buildFace(this.face, this.resolution);
     const mat = material || new THREE.MeshStandardMaterial({

--- a/src/GeometryBuilder.js
+++ b/src/GeometryBuilder.js
@@ -14,9 +14,13 @@ function cubeFaceVector(face, u, v) {
 }
 
 export default class GeometryBuilder {
-  constructor(noiseGen, radius = 1) {
-    this.noiseGen = noiseGen;
+  constructor(heightStack, radius = 1) {
+    this.heightStack = heightStack;
     this.radius = radius;
+  }
+
+  getVertexHeight(x, y, z) {
+    return 1 + this.heightStack.getHeight(x, y, z);
   }
 
   buildFace(face, resolution = 16) {
@@ -28,7 +32,7 @@ export default class GeometryBuilder {
         const v = (y / resolution) * 2 - 1;
         const cube = cubeFaceVector(face, u, v);
         const sphere = cubeToSphere(cube);
-        const height = 1 + 0.1 * this.noiseGen.getElevation(sphere.x, sphere.y, sphere.z);
+        const height = this.getVertexHeight(sphere.x, sphere.y, sphere.z);
         vertices.push(sphere.x * this.radius * height,
                       sphere.y * this.radius * height,
                       sphere.z * this.radius * height);

--- a/src/HeightmapStack.js
+++ b/src/HeightmapStack.js
@@ -1,0 +1,105 @@
+import FastNoiseLite from 'fastnoise-lite';
+
+export class Modifier {
+  apply(x, y, z, prevHeight, context) {
+    return prevHeight;
+  }
+}
+
+export class FBMModifier extends Modifier {
+  constructor(fnlInstance, amplitude = 1.0, frequency = 1.0, octaves = 5) {
+    super();
+    this.fnl = fnlInstance;
+    this.amplitude = amplitude;
+    this.frequency = frequency;
+    this.octaves = octaves;
+  }
+
+  apply(x, y, z, prevHeight, context) {
+    let value = 0;
+    let amp = this.amplitude;
+    let freq = this.frequency;
+
+    let sx = x;
+    let sy = y;
+    let sz = z;
+    if (context.warped) {
+      sx = context.warped.x;
+      sy = context.warped.y;
+      sz = context.warped.z;
+    }
+
+    for (let i = 0; i < this.octaves; i++) {
+      value += this.fnl.GetNoise(sx * freq, sy * freq, sz * freq) * amp;
+      freq *= 2;
+      amp *= 0.5;
+    }
+
+    return prevHeight + value;
+  }
+}
+
+export class DomainWarpModifier extends Modifier {
+  constructor(fnlInstance, intensity = 0.2) {
+    super();
+    this.fnl = fnlInstance;
+    this.intensity = intensity;
+  }
+
+  apply(x, y, z, prevHeight, context) {
+    const warp = this.fnl.GetNoise(x, y, z) * this.intensity;
+    context.warped = { x: x + warp, y: y + warp, z: z + warp };
+    return prevHeight;
+  }
+}
+
+export class TerraceModifier extends Modifier {
+  constructor(steps = 5, heightRange = 1.0) {
+    super();
+    this.steps = steps;
+    this.heightRange = heightRange;
+  }
+
+  apply(x, y, z, prevHeight, context) {
+    const stepped = Math.floor(prevHeight * this.steps) / this.steps;
+    return stepped * this.heightRange;
+  }
+}
+
+export class CliffModifier extends Modifier {
+  constructor(slopeThreshold = 0.3, cliffBoost = 2.0) {
+    super();
+    this.threshold = slopeThreshold;
+    this.boost = cliffBoost;
+  }
+
+  apply(x, y, z, prevHeight, context) {
+    const slope = Math.abs((context.prevHeight ?? prevHeight) - prevHeight);
+    if (slope > this.threshold) {
+      return prevHeight * this.boost;
+    }
+    return prevHeight;
+  }
+}
+
+export default class HeightmapStack {
+  constructor(seed) {
+    this.seed = seed;
+    this.modifiers = [];
+    this.context = {};
+  }
+
+  add(modifier) {
+    this.modifiers.push(modifier);
+  }
+
+  getHeight(x, y, z) {
+    let height = 0;
+    this.context.prevHeight = 0;
+    for (const mod of this.modifiers) {
+      height = mod.apply(x, y, z, height, this.context);
+      this.context.prevHeight = height;
+    }
+    return height;
+  }
+}

--- a/src/PlanetManager.js
+++ b/src/PlanetManager.js
@@ -1,15 +1,26 @@
 import * as THREE from 'three';
-import NoiseGenerator from './NoiseGenerator.js';
+import FastNoiseLite from 'fastnoise-lite';
 import GeometryBuilder from './GeometryBuilder.js';
 import FaceChunk from './FaceChunk.js';
 import ChunkLODController from './ChunkLODController.js';
 import createTerrainMaterial from './materials/TerrainShader.js';
+import HeightmapStack, { FBMModifier, DomainWarpModifier, TerraceModifier, CliffModifier } from './HeightmapStack.js';
 
 export default class PlanetManager {
   constructor(scene, radius = 1) {
     this.scene = scene;
-    this.noise = new NoiseGenerator(1234);
-    this.builder = new GeometryBuilder(this.noise, radius);
+
+    const seed = 1234;
+    const fnl = new FastNoiseLite(seed);
+    fnl.SetNoiseType(FastNoiseLite.NoiseType.OpenSimplex2);
+
+    this.heightStack = new HeightmapStack(seed);
+    this.heightStack.add(new DomainWarpModifier(fnl, 0.2));
+    this.heightStack.add(new FBMModifier(fnl, 1.0, 1.2, 5));
+    this.heightStack.add(new TerraceModifier(8, 0.8));
+    // this.heightStack.add(new CliffModifier(0.25, 2.2));
+
+    this.builder = new GeometryBuilder(this.heightStack, radius);
     this.lod = new ChunkLODController();
     this.chunks = [];
 


### PR DESCRIPTION
## Summary
- add `HeightmapStack` with modular modifiers
- use height stack in `GeometryBuilder` and expose `getVertexHeight`
- wire `PlanetManager` to configure the height stack with noise-based modifiers
- expose height getter via `FaceChunk`
- update documentation for new height generation system

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685888ce713c8326b11108243b3d32f5