### PR TITLE
Implement plateau modifier and tests

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -51,6 +51,11 @@ ProceduralPlanetLOD aims to create a fully procedural planet that dynamically ad
 ### Terrain Generation
 - **HeightmapStack** combines modular modifiers (FBM noise, domain warp, terracing, etc.) using FastNoiseLite for deterministic results.
 - Each modifier can be toggled or extended for biome control and GPU-based implementations.
+- Screenshots illustrate the effect of each modifier:
+  - `FBMModifier` ![fbm](docs/screenshots/fbm.png)
+  - `DomainWarpModifier` ![domainwarp](docs/screenshots/domain-warp.png)
+  - `TerraceModifier` ![terrace](docs/screenshots/terrace.png)
+  - `CliffModifier` ![cliff](docs/screenshots/cliff.png)
 
 ### Shader Structure
 - **TerrainShader** colors terrain based on height or biome data.
@@ -67,7 +72,7 @@ ProceduralPlanetLOD aims to create a fully procedural planet that dynamically ad
 
 ## Development and Testing
 - Start the demo with `npm start` and open `http://localhost:5173` in the browser.
-- Use `npm test` as a placeholder for automated tests (none yet).
+- Run `npm test` to verify deterministic height generation.
 - Keep code modular to make integration with bundlers like Vite or Webpack straightforward.
 
 ## Future Extensions

--- a/docs/screenshots/README.md
+++ b/docs/screenshots/README.md
@@ -1,0 +1,1 @@
+Place screenshots of modifiers here.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "start": "vite",
-    "test": "echo \"No tests\""
+    "test": "node test/deterministicHeight.js"
   },
   "dependencies": {
     "three": "^0.177.0",

--- a/src/HeightmapStack.js
+++ b/src/HeightmapStack.js
@@ -81,6 +81,21 @@ export class CliffModifier extends Modifier {
   }
 }
 
+export class PlateauModifier extends Modifier {
+  constructor(threshold = 0.6, plateauFactor = 0.3) {
+    super();
+    this.threshold = threshold;
+    this.factor = plateauFactor;
+  }
+
+  apply(x, y, z, prevHeight) {
+    if (prevHeight > this.threshold) {
+      return this.threshold + (prevHeight - this.threshold) * this.factor;
+    }
+    return prevHeight;
+  }
+}
+
 export default class HeightmapStack {
   constructor(seed) {
     this.seed = seed;

--- a/src/NoiseGenerator.js
+++ b/src/NoiseGenerator.js
@@ -1,3 +1,5 @@
+// NOTE: This wrapper remains for backward compatibility. New features should
+// rely on HeightmapStack and its modifiers instead.
 import FastNoiseLite from 'fastnoise-lite';
 
 export default class NoiseGenerator {

--- a/test/deterministicHeight.js
+++ b/test/deterministicHeight.js
@@ -1,0 +1,29 @@
+import assert from 'assert';
+import FastNoiseLite from 'fastnoise-lite';
+import HeightmapStack, { FBMModifier, DomainWarpModifier, TerraceModifier, PlateauModifier } from '../src/HeightmapStack.js';
+
+function createStack(seed) {
+  const fnl = new FastNoiseLite(seed);
+  fnl.SetNoiseType(FastNoiseLite.NoiseType.OpenSimplex2);
+  const stack = new HeightmapStack(seed);
+  stack.add(new DomainWarpModifier(fnl, 0.2));
+  stack.add(new FBMModifier(fnl, 1.0, 1.2, 5));
+  stack.add(new TerraceModifier(8, 0.8));
+  stack.add(new PlateauModifier(0.5, 0.2));
+  return stack;
+}
+
+const coords = [
+  [0.1, 0.2, 0.3],
+  [0.4, -0.2, -0.1],
+  [0.8, 0.5, 0.9]
+];
+
+const stack1 = createStack(1234);
+const heights1 = coords.map(([x, y, z]) => stack1.getHeight(x, y, z));
+
+const stack2 = createStack(1234);
+const heights2 = coords.map(([x, y, z]) => stack2.getHeight(x, y, z));
+
+assert.deepStrictEqual(heights1, heights2);
+console.log('Deterministic heightmap test passed.');


### PR DESCRIPTION
## Summary
- mark `NoiseGenerator.js` as legacy
- introduce `PlateauModifier`
- document modifier screenshots
- add deterministic heightmap test and update NPM script

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858945da6bc832690636f2c98e8340b