### PR TITLE
Implement async chunk rebuild and add water mesh

### DIFF
--- a/src/FaceChunk.js
+++ b/src/FaceChunk.js
@@ -1,9 +1,6 @@
 import * as THREE from 'three';
 import { sphereIntersectsFrustum } from './utils/BoundingUtils.js';
 
-import { sphereIntersectsFrustum } from './utils/BoundingUtils.js';
-
-
 export default class FaceChunk {
   constructor(face, builder, resolution = 16) {
     this.face = face;
@@ -68,6 +65,17 @@ export default class FaceChunk {
   rebuild() {
     if (!this.mesh) return;
     const newGeom = this.builder.buildFace(this.face, this.resolution);
+    this.mesh.geometry.dispose();
+    this.mesh.geometry = newGeom;
+  }
+
+  async rebuildAsync(progressCallback) {
+    if (!this.mesh) return;
+    const newGeom = await this.builder.buildFaceAsync(
+      this.face,
+      this.resolution,
+      progressCallback
+    );
     this.mesh.geometry.dispose();
     this.mesh.geometry = newGeom;
   }

--- a/src/GeometryBuilder.js
+++ b/src/GeometryBuilder.js
@@ -54,4 +54,40 @@ export default class GeometryBuilder {
     geometry.computeVertexNormals();
     return geometry;
   }
+
+  async buildFaceAsync(face, resolution = 16, progressCallback) {
+    const vertices = [];
+    const indices = [];
+    for (let y = 0; y <= resolution; y++) {
+      for (let x = 0; x <= resolution; x++) {
+        const u = (x / resolution) * 2 - 1;
+        const v = (y / resolution) * 2 - 1;
+        const cube = cubeFaceVector(face, u, v);
+        const sphere = cubeToSphere(cube);
+        const height = this.getVertexHeight(sphere.x, sphere.y, sphere.z);
+        vertices.push(
+          sphere.x * this.radius * height,
+          sphere.y * this.radius * height,
+          sphere.z * this.radius * height
+        );
+      }
+      if (progressCallback) progressCallback(y / resolution);
+      await new Promise((r) => setTimeout(r, 0));
+    }
+    for (let y = 0; y < resolution; y++) {
+      for (let x = 0; x < resolution; x++) {
+        const i = y * (resolution + 1) + x;
+        const a = i;
+        const b = i + 1;
+        const c = i + resolution + 1;
+        const d = c + 1;
+        indices.push(a, c, b, b, c, d);
+      }
+    }
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.Float32BufferAttribute(vertices, 3));
+    geometry.setIndex(indices);
+    geometry.computeVertexNormals();
+    return geometry;
+  }
 }

--- a/src/PlanetManager.js
+++ b/src/PlanetManager.js
@@ -4,6 +4,7 @@ import GeometryBuilder from './GeometryBuilder.js';
 import FaceChunk from './FaceChunk.js';
 import ChunkLODController from './ChunkLODController.js';
 import createTerrainMaterial from './materials/TerrainShader.js';
+import createWaterMaterial from './materials/WaterShader.js';
 import HeightmapStack, { FBMModifier, DomainWarpModifier, TerraceModifier, CliffModifier } from './HeightmapStack.js';
 import { getCameraFrustum } from './utils/BoundingUtils.js';
 
@@ -35,6 +36,12 @@ export default class PlanetManager {
       this.chunks.push(chunk);
     }
 
+    this.water = new THREE.Mesh(
+      new THREE.SphereGeometry(radius * 0.99, 32, 32),
+      createWaterMaterial()
+    );
+    scene.add(this.water);
+
     const light = new THREE.DirectionalLight(0xffffff, 1);
     light.position.set(5, 5, 5);
     scene.add(light);
@@ -50,9 +57,9 @@ export default class PlanetManager {
 
   async rebuild(progressCallback) {
     for (let i = 0; i < this.chunks.length; i++) {
-      this.chunks[i].rebuild();
+      await this.chunks[i].rebuildAsync();
       if (progressCallback) progressCallback((i + 1) / this.chunks.length);
-      await new Promise(requestAnimationFrame);
+      await new Promise((r) => requestAnimationFrame(r));
     }
   }
 


### PR DESCRIPTION
## Summary
- support async geometry generation in `GeometryBuilder`
- expose `rebuildAsync` in `FaceChunk`
- update planet rebuild flow to use async operations
- add simple water sphere to `PlanetManager`
- remove duplicate import in `FaceChunk`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858a1eaaec083269db77ffbb608f979