### PR TITLE
Integrate GPU terrain shader

### DIFF
--- a/src/PlanetManager.js
+++ b/src/PlanetManager.js
@@ -9,34 +9,49 @@ import HeightmapStack, { FBMModifier, DomainWarpModifier, TerraceModifier, Cliff
 import { getCameraFrustum } from './utils/BoundingUtils.js';
 
 export default class PlanetManager {
-  constructor(scene, radius = 1) {
+  constructor(scene, radius = 1, useGPU = true) {
     this.scene = scene;
+    this.useGPU = useGPU;
 
     const seed = 1234;
-    const fnl = new FastNoiseLite(seed);
-    fnl.SetNoiseType(FastNoiseLite.NoiseType.OpenSimplex2);
+    this.seed = seed;
+    let fnl;
+    if (!this.useGPU) {
+      fnl = new FastNoiseLite(seed);
+      fnl.SetNoiseType(FastNoiseLite.NoiseType.OpenSimplex2);
+    }
 
-    this.heightStack = new HeightmapStack(seed);
-    this.domainWarp = new DomainWarpModifier(fnl, 0.2);
-    this.fbm = new FBMModifier(fnl, 1.0, 1.2, 5);
-    this.terrace = new TerraceModifier(8, 0.8);
-    this.cliff = new CliffModifier(0.25, 2.2);
+    if (this.useGPU) {
+      this.heightStack = { getHeight() { return 0; } };
+    } else {
+      this.heightStack = new HeightmapStack(seed);
+      this.domainWarp = new DomainWarpModifier(fnl, 0.2);
+      this.fbm = new FBMModifier(fnl, 1.0, 1.2, 5);
+      this.terrace = new TerraceModifier(8, 0.8);
+      this.cliff = new CliffModifier(0.25, 2.2);
 
-    this.modifiers = [this.domainWarp, this.fbm, this.terrace];
-    for (const m of this.modifiers) this.heightStack.add(m);
+      this.modifiers = [this.domainWarp, this.fbm, this.terrace];
+      for (const m of this.modifiers) this.heightStack.add(m);
 
-    this.useDomainWarp = true;
-    this.useTerrace = true;
-    this.useCliff = false;
+      this.useDomainWarp = true;
+      this.useTerrace = true;
+      this.useCliff = false;
+    }
 
     this.builder = new GeometryBuilder(this.heightStack, radius);
     this.lod = new ChunkLODController();
     this.chunks = [];
+    this.terrainMaterial = createTerrainMaterial({
+      seed,
+      radius,
+      amplitude: 0.3,
+      frequency: 1.2,
+    });
 
     const faces = ['px', 'nx', 'py', 'ny', 'pz', 'nz'];
     for (const face of faces) {
       const chunk = new FaceChunk(face, this.builder, 32);
-      chunk.createMesh(createTerrainMaterial());
+      chunk.createMesh(this.terrainMaterial);
       chunk.addToScene(scene);
       this.chunks.push(chunk);
     }
@@ -61,12 +76,17 @@ export default class PlanetManager {
     terraceSteps,
     terraceRange,
   }) {
-    if (amplitude !== undefined) this.fbm.amplitude = amplitude;
-    if (frequency !== undefined) this.fbm.frequency = frequency;
-    if (octaves !== undefined) this.fbm.octaves = octaves;
-    if (warpIntensity !== undefined) this.domainWarp.intensity = warpIntensity;
-    if (terraceSteps !== undefined) this.terrace.steps = terraceSteps;
-    if (terraceRange !== undefined) this.terrace.heightRange = terraceRange;
+    if (this.useGPU) {
+      if (amplitude !== undefined) this.terrainMaterial.uniforms.uAmplitude.value = amplitude;
+      if (frequency !== undefined) this.terrainMaterial.uniforms.uFrequency.value = frequency;
+    } else {
+      if (amplitude !== undefined) this.fbm.amplitude = amplitude;
+      if (frequency !== undefined) this.fbm.frequency = frequency;
+      if (octaves !== undefined) this.fbm.octaves = octaves;
+      if (warpIntensity !== undefined) this.domainWarp.intensity = warpIntensity;
+      if (terraceSteps !== undefined) this.terrace.steps = terraceSteps;
+      if (terraceRange !== undefined) this.terrace.heightRange = terraceRange;
+    }
   }
 
   setModifierEnabled(name, enabled) {
@@ -87,6 +107,8 @@ export default class PlanetManager {
   }
 
   _toggleModifier(mod, enabled) {
+    if (this.useGPU) return;
+
     const hasMod = this.heightStack.modifiers.includes(mod);
     if (enabled && !hasMod) {
       this.heightStack.modifiers.push(mod);

--- a/src/materials/TerrainShader.js
+++ b/src/materials/TerrainShader.js
@@ -1,8 +1,83 @@
 import * as THREE from 'three';
 
-export default function createTerrainMaterial() {
-  return new THREE.MeshStandardMaterial({
-    color: 0x88aa55,
+const vertexShader = /* glsl */`
+uniform float uAmplitude;
+uniform float uFrequency;
+uniform float uSeed;
+uniform float uRadius;
+varying float vHeight;
+
+float random(vec3 p) {
+  return fract(sin(dot(p + uSeed, vec3(12.9898, 78.233, 37.719))) * 43758.5453);
+}
+
+float noise(vec3 p) {
+  vec3 i = floor(p);
+  vec3 f = fract(p);
+  f = f * f * (3.0 - 2.0 * f);
+  float n000 = random(i + vec3(0.0, 0.0, 0.0));
+  float n100 = random(i + vec3(1.0, 0.0, 0.0));
+  float n010 = random(i + vec3(0.0, 1.0, 0.0));
+  float n110 = random(i + vec3(1.0, 1.0, 0.0));
+  float n001 = random(i + vec3(0.0, 0.0, 1.0));
+  float n101 = random(i + vec3(1.0, 0.0, 1.0));
+  float n011 = random(i + vec3(0.0, 1.0, 1.0));
+  float n111 = random(i + vec3(1.0, 1.0, 1.0));
+  float n00 = mix(n000, n100, f.x);
+  float n10 = mix(n010, n110, f.x);
+  float n01 = mix(n001, n101, f.x);
+  float n11 = mix(n011, n111, f.x);
+  float n0 = mix(n00, n10, f.y);
+  float n1 = mix(n01, n11, f.y);
+  return mix(n0, n1, f.z) * 2.0 - 1.0;
+}
+
+float fbm(vec3 p) {
+  float v = 0.0;
+  float a = 0.5;
+  for (int i = 0; i < 5; i++) {
+    v += noise(p) * a;
+    p *= 2.0;
+    a *= 0.5;
+  }
+  return v;
+}
+
+void main() {
+  vec3 pos = position;
+  float h = fbm(normalize(pos) * uFrequency);
+  vHeight = h;
+  pos = normalize(pos) * (uRadius + h * uAmplitude);
+  gl_Position = projectionMatrix * modelViewMatrix * vec4(pos, 1.0);
+}
+`;
+
+const fragmentShader = /* glsl */`
+varying float vHeight;
+
+void main() {
+  vec3 low = vec3(0.2, 0.6, 0.3);
+  vec3 high = vec3(1.0, 1.0, 1.0);
+  vec3 color = mix(low, high, vHeight * 0.5 + 0.5);
+  gl_FragColor = vec4(color, 1.0);
+}
+`;
+
+export default function createTerrainMaterial({
+  amplitude = 0.3,
+  frequency = 1.0,
+  seed = 0.0,
+  radius = 1.0,
+} = {}) {
+  return new THREE.ShaderMaterial({
+    uniforms: {
+      uAmplitude: { value: amplitude },
+      uFrequency: { value: frequency },
+      uSeed: { value: seed },
+      uRadius: { value: radius },
+    },
+    vertexShader,
+    fragmentShader,
     flatShading: true,
   });
 }


### PR DESCRIPTION
## Summary
- implement custom GPU shader for terrain displacement and coloring
- update `PlanetManager` to optionally use GPU-based terrain

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858aca8ca6483269ff4adff24058077