### PR TITLE
Improve terrain shading

### DIFF
--- a/PROJECT.md
+++ b/PROJECT.md
@@ -58,7 +58,7 @@ ProceduralPlanetLOD aims to create a fully procedural planet that dynamically ad
   - `CliffModifier` ![cliff](docs/screenshots/cliff.png)
 
 ### Shader Structure
-- **TerrainShader** colors terrain based on height or biome data.
+- **TerrainShader** colors terrain based on height, blending rock and snow on steep slopes.
 - **WaterShader** (optional) renders a water surface with transparency and simple waves.
 
 ## Implementation Plan


### PR DESCRIPTION
## Summary
- blend grass, rock and snow colors in `TerrainShader`
- note slope-based colors in project docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6858b44d98e883269e61e86eb75848e3