### PR TITLE
Improve plate modifier ordering and tests

### DIFF
--- a/src/PlanetManager.js
+++ b/src/PlanetManager.js
@@ -6,6 +6,8 @@ import ChunkLODController from './ChunkLODController.js';
 import createTerrainMaterial from './materials/TerrainShader.js';
 import createWaterMaterial from './materials/WaterShader.js';
 import HeightmapStack, { FBMModifier, DomainWarpModifier, TerraceModifier, CliffModifier } from './HeightmapStack.js';
+import PlateTectonics from './PlateTectonics.js';
+import PlateModifier from './PlateModifier.js';
 import { getCameraFrustum } from './utils/BoundingUtils.js';
 
 export default class PlanetManager {
@@ -30,7 +32,10 @@ export default class PlanetManager {
       this.terrace = new TerraceModifier(8, 0.8);
       this.cliff = new CliffModifier(0.25, 2.2);
 
-      this.modifiers = [this.domainWarp, this.fbm, this.terrace];
+      this.plates = new PlateTectonics(seed, 20, 0.1);
+      this.plateModifier = new PlateModifier(this.plates, 0.05);
+
+      this.modifiers = [this.domainWarp, this.fbm, this.terrace, this.plateModifier];
       for (const m of this.modifiers) this.heightStack.add(m);
 
       this.useDomainWarp = true;
@@ -117,10 +122,11 @@ export default class PlanetManager {
     }
     // Re-order modifiers to maintain consistent stack
     const ordered = [];
-    if (this.useDomainWarp && ordered.indexOf(this.domainWarp) === -1) ordered.push(this.domainWarp);
+    if (this.useDomainWarp) ordered.push(this.domainWarp);
     ordered.push(this.fbm);
-    if (this.useTerrace && ordered.indexOf(this.terrace) === -1) ordered.push(this.terrace);
-    if (this.useCliff && ordered.indexOf(this.cliff) === -1) ordered.push(this.cliff);
+    if (this.useTerrace) ordered.push(this.terrace);
+    if (this.useCliff) ordered.push(this.cliff);
+    ordered.push(this.plateModifier);
     this.heightStack.modifiers = ordered;
   }
 

--- a/src/PlateModifier.js
+++ b/src/PlateModifier.js
@@ -1,0 +1,32 @@
+import * as THREE from 'three';
+import FastNoiseLite from 'fastnoise-lite';
+import { Modifier } from './HeightmapStack.js';
+
+export default class PlateModifier extends Modifier {
+  constructor(plates, boundaryRadius = 0.05) {
+    super();
+    this.plates = plates;
+    this.boundaryRadius = boundaryRadius;
+    this.noise = new FastNoiseLite(plates.seed + 1);
+    this.noise.SetNoiseType(FastNoiseLite.NoiseType.OpenSimplex2);
+  }
+
+  apply(x, y, z, prevHeight) {
+    const info = this.plates.getBoundaryInfo(new THREE.Vector3(x, y, z), this.boundaryRadius);
+    if (!info) return prevHeight;
+    const falloff = 1 - info.distance / this.boundaryRadius;
+    switch (info.type) {
+      case 'divergent':
+        return prevHeight - falloff * 0.05;
+      case 'convergent': {
+        const volcanoFactor = Math.pow(falloff, 4);
+        const volcanoNoise = this.noise.GetNoise(x * 10, y * 10, z * 10);
+        return prevHeight + falloff * 0.05 + volcanoFactor * volcanoNoise * 0.1;
+      }
+      case 'transform':
+        return prevHeight + falloff * 0.02;
+      default:
+        return prevHeight;
+    }
+  }
+}

--- a/src/PlateTectonics.js
+++ b/src/PlateTectonics.js
@@ -1,0 +1,70 @@
+import * as THREE from 'three';
+
+function mulberry32(a) {
+  return function() {
+    let t = (a += 0x6D2B79F5);
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+function randomPointOnSphere(rand) {
+  const u = rand() * 2 - 1;
+  const theta = rand() * Math.PI * 2;
+  const s = Math.sqrt(1 - u * u);
+  return new THREE.Vector3(s * Math.cos(theta), s * Math.sin(theta), u);
+}
+
+function randomTangent(center, rand) {
+  const r = new THREE.Vector3(rand(), rand(), rand()).normalize();
+  return r.sub(center.clone().multiplyScalar(center.dot(r))).normalize();
+}
+
+export default class PlateTectonics {
+  constructor(seed = 1337, plateCount = 16, boundaryRadius = 0.1) {
+    this.seed = seed;
+    this.rand = mulberry32(seed);
+    this.boundaryRadius = boundaryRadius;
+    this.plates = [];
+    for (let i = 0; i < plateCount; i++) {
+      const center = randomPointOnSphere(this.rand);
+      const vector = randomTangent(center, this.rand);
+      this.plates.push({ id: i, center, vector, type: 'oceanic' });
+    }
+  }
+
+  getNearest(point) {
+    let first = null;
+    let second = null;
+    for (const p of this.plates) {
+      const dist = point.distanceTo(p.center);
+      if (!first || dist < first.dist) {
+        second = first;
+        first = { plate: p, dist };
+      } else if (!second || dist < second.dist) {
+        second = { plate: p, dist };
+      }
+    }
+    return { first, second };
+  }
+
+  getBoundaryInfo(point, radius = this.boundaryRadius) {
+    const n = point.clone().normalize();
+    const { first, second } = this.getNearest(n);
+    if (!first || !second) return null;
+    const diff = second.dist - first.dist;
+    if (diff > radius) return null;
+
+    const a = first.plate;
+    const b = second.plate;
+    const relative = b.vector.clone().sub(a.vector);
+    const normal = b.center.clone().sub(a.center).normalize();
+    const dot = relative.dot(normal);
+    let type;
+    if (dot > 0.3) type = 'divergent';
+    else if (dot < -0.3) type = 'convergent';
+    else type = 'transform';
+    return { type, distance: diff };
+  }
+}

--- a/test/deterministicHeight.js
+++ b/test/deterministicHeight.js
@@ -30,3 +30,4 @@ console.log('Deterministic heightmap test passed.');
 
 // Run frustum utils test
 import './frustumUtils.js';
+import './plateTectonics.js';

--- a/test/plateTectonics.js
+++ b/test/plateTectonics.js
@@ -1,0 +1,24 @@
+import assert from 'assert';
+import * as THREE from 'three';
+import PlateTectonics from '../src/PlateTectonics.js';
+
+const p1 = new PlateTectonics(42, 6, 0.1);
+const p2 = new PlateTectonics(42, 6, 0.1);
+
+assert.deepStrictEqual(
+  p1.plates.map(pl => pl.center.toArray()),
+  p2.plates.map(pl => pl.center.toArray())
+);
+assert.deepStrictEqual(
+  p1.plates.map(pl => pl.vector.toArray()),
+  p2.plates.map(pl => pl.vector.toArray())
+);
+
+const testPoint = p1.plates[0].center.clone().multiplyScalar(0.9);
+const info = p1.getBoundaryInfo(testPoint, 2);
+if (info) {
+  assert(['divergent', 'convergent', 'transform'].includes(info.type));
+}
+
+console.log('Plate tectonics deterministic test passed.');
+


### PR DESCRIPTION
## Summary
- preserve `PlateModifier` when toggling CPU modifiers
- add a deterministic test for `PlateTectonics`
- run new test from main test script

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6858b134d0cc8326a9135b3a00180eea