### PR TITLE
Fix debug view when GPU mode enabled

### DIFF
--- a/src/PlanetManager.js
+++ b/src/PlanetManager.js
@@ -66,14 +66,16 @@ export default class PlanetManager {
       this.chunks.push(chunk);
     }
 
-    this.water = new THREE.Mesh(
-      new THREE.SphereGeometry(radius * 0.99, 32, 32),
-      createWaterMaterial({ envMap: scene.environment || null })
-    );
-    scene.add(this.water);
-    this.debugView.addToScene(scene);
-    this.debugView.group.visible = false;
-    this.showDebug = false;
+      this.water = new THREE.Mesh(
+        new THREE.SphereGeometry(radius * 0.99, 32, 32),
+        createWaterMaterial({ envMap: scene.environment || null })
+      );
+      scene.add(this.water);
+      if (this.debugView) {
+        this.debugView.addToScene(scene);
+        this.debugView.group.visible = false;
+      }
+      this.showDebug = false;
 
     const light = new THREE.DirectionalLight(0xffffff, 1);
     light.position.set(5, 5, 5);
@@ -168,7 +170,9 @@ export default class PlanetManager {
 
   setDebugVisible(visible) {
     this.showDebug = visible;
-    this.debugView.group.visible = visible;
+    if (this.debugView) {
+      this.debugView.group.visible = visible;
+    }
   }
 
   update(camera) {


### PR DESCRIPTION
## Summary
- don't assume `debugView` exists when using GPU path
- check for debugView presence in `setDebugVisible`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68591adfe0648326bff397c071b72e77