### PR TITLE
Improve terrain layer realism

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,4 +21,7 @@ This file lists outstanding tasks and opportunities for future improvements.
 
 - [x] Improve progress reporting when geometry is generated in Web Workers.
 
+- [x] Clamp combined terrain layers to the [-1, 1] range so heightmap
+  modifications remain realistic.
+
 

--- a/README.md
+++ b/README.md
@@ -25,3 +25,18 @@ npm test
 ## Documentation
 
 See [`PROJECT.md`](PROJECT.md) for an overview of the architecture and future plans. Modifier screenshots are located in [`docs/screenshots`](docs/screenshots).
+
+## Terrain Layers
+
+The `LayerPipeline` combines several modifiers to create the final heightmap. Layers
+are evaluated in order and clamped so the resulting heights remain within `[-1, 1]`
+for realistic geometry. The main layers are:
+
+1. **baseNoise** – domain‑warped fractal noise defining large-scale features.
+2. **tectonics** – displaces terrain near plate boundaries to form trenches and ridges.
+3. **elevation** – merges the previous layers and clamps the result to prevent
+   extreme spikes or pits.
+4. **moisture/temperature** – additional noise used for biome selection.
+
+Adjusting these layers in the UI or code allows experimentation while keeping
+terrain generation stable.

--- a/src/HeightmapStack.js
+++ b/src/HeightmapStack.js
@@ -110,14 +110,14 @@ export default class HeightmapStack {
   }
 
   getHeight(x, y, z) {
-
     const context = { ...this.context };
     let height = 0;
     for (const mod of this.modifiers) {
       context.prevHeight = height;
       height = mod.apply(x, y, z, height, context);
-
     }
-    return height;
+    // Clamp to a sane range so later layers receive meaningful values
+    // and geometry does not collapse or explode.
+    return Math.max(-1, Math.min(1, height));
   }
 }

--- a/src/LayerPipeline.js
+++ b/src/LayerPipeline.js
@@ -33,7 +33,13 @@ export default class LayerPipeline {
 
     this.addLayer('baseNoise', (x, y, z, ctx) => this.baseStack.getHeight(x, y, z));
     this.addLayer('tectonics', (x, y, z, ctx) => this.plateModifier.apply(x, y, z, ctx.baseNoise || 0));
-    this.addLayer('elevation', (x, y, z, ctx) => (ctx.baseNoise || 0) + (ctx.tectonics || 0));
+    this.addLayer('elevation', (x, y, z, ctx) => {
+      const base = ctx.baseNoise || 0;
+      const tect = ctx.tectonics || 0;
+      // Blend the layers and clamp to keep terrain heights realistic
+      const h = base + tect;
+      return Math.max(-1, Math.min(1, h));
+    });
     this.addLayer('moisture', (x, y, z) => fnl.GetNoise(x * 0.5, y * 0.5, z * 0.5));
     this.addLayer('temperature', (x, y, z, ctx) => {
       const lat = Math.abs(y);


### PR DESCRIPTION
## Summary
- clamp combined terrain layers in HeightmapStack
- normalize elevation layer inside the pipeline
- outline layer order in README
- note terrain layer clamping task in AGENTS

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68591dacabe8832699a7cdeb1e71969b