### PR TITLE
Add simple day-night cycle

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,4 +24,6 @@ This file lists outstanding tasks and opportunities for future improvements.
 - [x] Clamp combined terrain layers to the [-1, 1] range so heightmap
   modifications remain realistic.
 
+- [x] Add a simple day/night cycle by orbiting the directional light around the planet.
+
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ Move the sliders in the UI to tweak noise parameters. Click **Rebuild** to regen
 npm test
 ```
 
+The demo also includes a basic day/night cycle with the main light orbiting the planet.
+
 ## Documentation
 
 See [`PROJECT.md`](PROJECT.md) for an overview of the architecture and future plans. Modifier screenshots are located in [`docs/screenshots`](docs/screenshots).

--- a/main.js
+++ b/main.js
@@ -18,6 +18,7 @@ camera.position.set(0, 3, 6);
 const controls = new OrbitControls(camera, renderer.domElement);
 
 const planet = new PlanetManager(scene, 1, true, true);
+planet.setDayNightCycleEnabled(true);
 
 const amp = document.getElementById('amp');
 const freq = document.getElementById('freq');

--- a/src/PlanetManager.js
+++ b/src/PlanetManager.js
@@ -53,10 +53,12 @@ export default class PlanetManager {
       }
       this.showDebug = false;
 
-    const light = new THREE.DirectionalLight(0xffffff, 1);
-    light.position.set(5, 5, 5);
-    scene.add(light);
+    this.light = new THREE.DirectionalLight(0xffffff, 1);
+    this.light.position.set(5, 5, 5);
+    scene.add(this.light);
     scene.add(new THREE.AmbientLight(0x333333));
+    this.enableDayNight = false;
+    this.lightAngle = 0;
   }
 
   setNoiseParams({ amplitude, frequency, octaves, warpIntensity }) {
@@ -98,8 +100,22 @@ export default class PlanetManager {
     }
   }
 
+  setDayNightCycleEnabled(enabled) {
+    this.enableDayNight = enabled;
+  }
+
   update(camera) {
     const frustum = getCameraFrustum(camera);
+    if (this.enableDayNight && this.light) {
+      this.lightAngle += 0.01;
+      const r = 5;
+      this.light.position.set(
+        Math.cos(this.lightAngle) * r,
+        Math.sin(this.lightAngle) * r,
+        5
+      );
+      this.light.lookAt(0, 0, 0);
+    }
     for (const chunk of this.chunks) {
       chunk.update(camera, this.lod, frustum);
     }


### PR DESCRIPTION
## Summary
- add new task to `AGENTS.md`
- update README usage section with lighting note
- enable day/night cycle in `main.js`
- implement orbiting light in `PlanetManager`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68592116880c8326895aebf02e16896b