### PR TITLE
Add status feedback during rebuild

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project demonstrates a procedural planet generated with a quadtree level of
 
 ## Usage
 
-Move the sliders in the UI to tweak noise parameters. Click **Rebuild** to regenerate planet chunks. A progress bar in the UI now updates in real time while geometry is built in Web Workers. Tests can be run with:
+Move the sliders in the UI to tweak noise parameters. Click **Rebuild** to regenerate planet chunks. A progress bar in the UI now updates in real time while geometry is built in Web Workers. Status messages below the bar indicate which chunk is currently building. Tests can be run with:
 
 ```bash
 npm test
@@ -31,7 +31,7 @@ See [`PROJECT.md`](PROJECT.md) for an overview of the architecture and future pl
 ## Terrain Layers
 
 The `LayerPipeline` combines several modifiers to create the final heightmap. Layers
-are evaluated in order and clamped so the resulting heights remain within `[-1, 1]`
+are evaluated sequentially in a fixed hierarchy and clamped so the resulting heights remain within `[-1, 1]`
 for realistic geometry. The main layers are:
 
 1. **baseNoise** – domain‑warped fractal noise defining large-scale features.

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     #ui { position: absolute; top: 10px; left: 10px; background: rgba(255,255,255,0.8); padding: 10px; border-radius: 4px; font-family: sans-serif; }
     #progress { width: 200px; height: 8px; background: #eee; margin-top: 4px; }
     #progress-bar { height: 100%; width: 0; background: #76c7c0; }
+    #status { margin-top: 4px; font-size: 0.9em; }
   </style>
 </head>
 <body>
@@ -47,6 +48,7 @@
     </fieldset>
     <button id="rebuild">Rebuild</button>
     <div id="progress"><div id="progress-bar"></div></div>
+    <div id="status"></div>
   </div>
 
   <script type="module" src="/main.js"></script>

--- a/main.js
+++ b/main.js
@@ -37,6 +37,7 @@ const cloudFlowCheck = document.getElementById('cloudFlowCheck');
 const rockyCheck = document.getElementById('rockyCheck');
 const rebuildBtn = document.getElementById('rebuild');
 const progressBar = document.getElementById('progress-bar');
+const statusDiv = document.getElementById('status');
 
 function updateParams() {
   planet.setNoiseParams({
@@ -66,9 +67,16 @@ async function triggerRebuild() {
   rebuilding = true;
   updateParams();
   progressBar.style.width = '0%';
-  await planet.rebuild(p => {
-    progressBar.style.width = `${p * 100}%`;
-  });
+  statusDiv.textContent = 'Starting rebuild...';
+  await planet.rebuild(
+    p => {
+      progressBar.style.width = `${p * 100}%`;
+    },
+    msg => {
+      statusDiv.textContent = msg;
+    }
+  );
+  statusDiv.textContent = 'Idle';
   rebuilding = false;
 }
 

--- a/src/PlanetManager.js
+++ b/src/PlanetManager.js
@@ -80,7 +80,7 @@ export default class PlanetManager {
     if (this.pipeline) this.pipeline.setEnabled(id, enabled);
   }
 
-  async rebuild(progressCallback) {
+  async rebuild(progressCallback, statusCallback) {
     const total = this.chunks.length;
     const progress = new Array(total).fill(0);
 
@@ -92,11 +92,18 @@ export default class PlanetManager {
       }
     };
 
+    if (statusCallback) statusCallback('Starting rebuild');
+
     for (let i = 0; i < total; i++) {
-      await this.chunks[i].rebuildAsync((p) => update(i, p));
+      const chunk = this.chunks[i];
+      if (statusCallback) statusCallback(`Building ${chunk.face}`);
+      await chunk.rebuildAsync((p) => update(i, p));
       update(i, 1);
+      if (statusCallback) statusCallback(`Finished ${chunk.face}`);
       await new Promise((r) => requestAnimationFrame(r));
     }
+
+    if (statusCallback) statusCallback('Rebuild complete');
   }
 
   setDebugVisible(visible) {


### PR DESCRIPTION
## Summary
- show detailed progress messages while rebuilding planet chunks
- expose status callback in `PlanetManager.rebuild`
- display status in the UI and document the new behavior
- clarify that terrain layers are evaluated in a fixed hierarchy

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_685925284140832694cc7c91fe994b62