### PR TITLE
Improve rebuild status formatting

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ This project demonstrates a procedural planet generated with a quadtree level of
 
 ## Usage
 
-Move the sliders in the UI to tweak noise parameters. Click **Rebuild** to regenerate planet chunks. A progress bar in the UI now updates in real time while geometry is built in Web Workers. Tests can be run with:
+Move the sliders in the UI to tweak noise parameters. Click **Rebuild** to regenerate planet chunks. A progress bar in the UI now updates in real time while geometry is built in Web Workers. Status messages below the bar show the current subtask in the format `Rebuild -> face (50%)`. Tests can be run with:
 
 ```bash
 npm test
@@ -31,7 +31,7 @@ See [`PROJECT.md`](PROJECT.md) for an overview of the architecture and future pl
 ## Terrain Layers
 
 The `LayerPipeline` combines several modifiers to create the final heightmap. Layers
-are evaluated in order and clamped so the resulting heights remain within `[-1, 1]`
+are evaluated sequentially in a fixed hierarchy and clamped so the resulting heights remain within `[-1, 1]`
 for realistic geometry. The main layers are:
 
 1. **baseNoise** – domain‑warped fractal noise defining large-scale features.

--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
     #ui { position: absolute; top: 10px; left: 10px; background: rgba(255,255,255,0.8); padding: 10px; border-radius: 4px; font-family: sans-serif; }
     #progress { width: 200px; height: 8px; background: #eee; margin-top: 4px; }
     #progress-bar { height: 100%; width: 0; background: #76c7c0; }
+    #status { margin-top: 4px; font-size: 0.9em; }
   </style>
 </head>
 <body>
@@ -47,6 +48,7 @@
     </fieldset>
     <button id="rebuild">Rebuild</button>
     <div id="progress"><div id="progress-bar"></div></div>
+    <div id="status"></div>
   </div>
 
   <script type="module" src="/main.js"></script>

--- a/main.js
+++ b/main.js
@@ -37,6 +37,7 @@ const cloudFlowCheck = document.getElementById('cloudFlowCheck');
 const rockyCheck = document.getElementById('rockyCheck');
 const rebuildBtn = document.getElementById('rebuild');
 const progressBar = document.getElementById('progress-bar');
+const statusDiv = document.getElementById('status');
 
 function updateParams() {
   planet.setNoiseParams({
@@ -66,9 +67,17 @@ async function triggerRebuild() {
   rebuilding = true;
   updateParams();
   progressBar.style.width = '0%';
-  await planet.rebuild(p => {
-    progressBar.style.width = `${p * 100}%`;
-  });
+  statusDiv.textContent = 'Rebuild -> starting';
+  await planet.rebuild(
+    p => {
+      progressBar.style.width = `${p * 100}%`;
+    },
+    ({ task, subtask, progress }) => {
+      const pct = Math.round(progress * 100);
+      statusDiv.textContent = `${task} -> ${subtask} (${pct}%)`;
+    }
+  );
+  statusDiv.textContent = 'Idle';
   rebuilding = false;
 }
 


### PR DESCRIPTION
## Summary
- format status updates as `task -> subtask (progress%)`
- forward structured progress from `PlanetManager.rebuild`
- document new message format in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685925284140832694cc7c91fe994b62