### PR TITLE
Add day/night cycle toggle to UI

### DIFF
--- a/index.html
+++ b/index.html
@@ -34,6 +34,9 @@
     <div>
       <label>Cliff Boost <input id="cliffBoost" type="range" min="1" max="4" step="0.1" value="2"></label>
     </div>
+    <div>
+      <label><input id="dayNightCheck" type="checkbox" checked> Day/Night Cycle</label>
+    </div>
     <fieldset>
       <legend>Layers</legend>
       <div><label><input id="baseNoiseCheck" type="checkbox" checked> baseNoise</label></div>

--- a/main.js
+++ b/main.js
@@ -18,7 +18,6 @@ camera.position.set(0, 3, 6);
 const controls = new OrbitControls(camera, renderer.domElement);
 
 const planet = new PlanetManager(scene, 1, true, true);
-planet.setDayNightCycleEnabled(true);
 
 const amp = document.getElementById('amp');
 const freq = document.getElementById('freq');
@@ -26,6 +25,8 @@ const octaves = document.getElementById('octaves');
 const warp = document.getElementById('warp');
 const cliffThreshold = document.getElementById('cliffThreshold');
 const cliffBoost = document.getElementById('cliffBoost');
+const dayNightCheck = document.getElementById('dayNightCheck');
+planet.setDayNightCycleEnabled(dayNightCheck.checked);
 const baseNoiseCheck = document.getElementById('baseNoiseCheck');
 const tectonicsCheck = document.getElementById('tectonicsCheck');
 const moistureCheck = document.getElementById('moistureCheck');
@@ -63,6 +64,7 @@ function updateParams() {
   planet.setLayerEnabled('rocky', rockyCheck.checked);
   planet.setDebugVisible(layerDebugCheck.checked);
   planet.setDebugLayer(layerSelect.value);
+  planet.setDayNightCycleEnabled(dayNightCheck.checked);
 }
 
 let rebuilding = false;
@@ -93,7 +95,7 @@ rebuildBtn.addEventListener('click', triggerRebuild);
   cliffThreshold, cliffBoost,
   baseNoiseCheck, tectonicsCheck, moistureCheck, temperatureCheck,
   biomeCheck, vegetationCheck, cloudDensityCheck, cloudFlowCheck,
-  rockyCheck, layerDebugCheck, layerSelect
+  rockyCheck, layerDebugCheck, layerSelect, dayNightCheck
 ].forEach(input => {
   input.addEventListener('input', triggerRebuild);
   if (input.type === 'checkbox') {


### PR DESCRIPTION
## Summary
- add Day/Night Cycle checkbox to the UI
- wire up checkbox to `PlanetManager.setDayNightCycleEnabled`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68593537bfd88326aab35585c3c9dbca