### PR TITLE
Add planet scale controls and ruler helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ npm test
 
 The demo also includes a basic day/night cycle with the main light orbiting the planet.
 
+Additional controls let you scale the entire planet and toggle on-screen rulers (grid and axes) for reference.
+
 ## Documentation
 
 See [`PROJECT.md`](PROJECT.md) for an overview of the architecture and future plans. Modifier screenshots are located in [`docs/screenshots`](docs/screenshots). Details about the rocky layer are in [`docs/RockyLayer.md`](docs/RockyLayer.md).

--- a/index.html
+++ b/index.html
@@ -37,6 +37,12 @@
     <div>
       <label><input id="dayNightCheck" type="checkbox" checked> Day/Night Cycle</label>
     </div>
+    <div>
+      <label>Scale <input id="scale" type="range" min="0.5" max="3" step="0.1" value="1"></label>
+    </div>
+    <div>
+      <label><input id="rulerCheck" type="checkbox" checked> Show Rulers</label>
+    </div>
     <fieldset>
       <legend>Layers</legend>
       <div><label><input id="baseNoiseCheck" type="checkbox" checked> baseNoise</label></div>

--- a/main.js
+++ b/main.js
@@ -17,6 +17,11 @@ camera.position.set(0, 3, 6);
 
 const controls = new OrbitControls(camera, renderer.domElement);
 
+const axes = new THREE.AxesHelper(2);
+const grid = new THREE.GridHelper(4, 4);
+scene.add(axes);
+scene.add(grid);
+
 const planet = new PlanetManager(scene, 1, true, true, renderer);
 
 const amp = document.getElementById('amp');
@@ -38,9 +43,15 @@ const cloudFlowCheck = document.getElementById('cloudFlowCheck');
 const rockyCheck = document.getElementById('rockyCheck');
 const layerDebugCheck = document.getElementById('layerDebugCheck');
 const layerSelect = document.getElementById('layerSelect');
+const scaleInput = document.getElementById('scale');
+const rulerCheck = document.getElementById('rulerCheck');
 const rebuildBtn = document.getElementById('rebuild');
 const progressBar = document.getElementById('progress-bar');
 const statusDiv = document.getElementById('status');
+
+axes.visible = rulerCheck.checked;
+grid.visible = rulerCheck.checked;
+planet.setScale(parseFloat(scaleInput.value));
 
 function updateParams() {
   planet.setNoiseParams({
@@ -65,6 +76,10 @@ function updateParams() {
   planet.setDebugVisible(layerDebugCheck.checked);
   planet.setDebugLayer(layerSelect.value);
   planet.setDayNightCycleEnabled(dayNightCheck.checked);
+  planet.setScale(parseFloat(scaleInput.value));
+  const show = rulerCheck.checked;
+  axes.visible = show;
+  grid.visible = show;
 }
 
 let rebuilding = false;
@@ -103,6 +118,13 @@ rebuildBtn.addEventListener('click', triggerRebuild);
   }
   if (input.tagName === 'SELECT') {
     input.addEventListener('change', triggerRebuild);
+  }
+});
+
+[scaleInput, rulerCheck].forEach(input => {
+  input.addEventListener('input', updateParams);
+  if (input.type === 'checkbox') {
+    input.addEventListener('change', updateParams);
   }
 });
 

--- a/src/FaceChunk.js
+++ b/src/FaceChunk.js
@@ -27,7 +27,9 @@ export default class FaceChunk {
     }
     this.center.multiplyScalar(this.builder.radius);
     this.radius = this.builder.radius * 1.1; // allow some slack for terrain height
-  }
+    this.baseCenter = this.center.clone();
+    this.baseRadius = this.radius;
+    }
 
   getVertexHeight(x, y, z) {
     return this.builder.getVertexHeight(x, y, z);
@@ -76,6 +78,11 @@ export default class FaceChunk {
     } finally {
       this.rebuilding = false;
     }
+  }
+
+  setScale(scale) {
+    this.center.copy(this.baseCenter).multiplyScalar(scale);
+    this.radius = this.baseRadius * scale;
   }
 
   async rebuildAsync(progressCallback) {

--- a/src/PlanetManager.js
+++ b/src/PlanetManager.js
@@ -13,6 +13,9 @@ import { getCameraFrustum } from './utils/BoundingUtils.js';
 export default class PlanetManager {
   constructor(scene, radius = 1, useGPU = true, useWorker = false, renderer = null) {
     this.scene = scene;
+    this.group = new THREE.Group();
+    this.scale = 1;
+    scene.add(this.group);
     this.useGPU = useGPU;
     this.useWorker = useWorker;
     this.renderer = renderer;
@@ -49,21 +52,21 @@ export default class PlanetManager {
     for (const face of faces) {
       const chunk = new FaceChunk(face, this.builder, 32, this.useWorker);
       chunk.createMesh(this.terrainMaterial);
-      chunk.addToScene(scene);
+      chunk.addToScene(this.group);
       this.chunks.push(chunk);
     }
 
-      this.water = new THREE.Mesh(
+    this.water = new THREE.Mesh(
         new THREE.SphereGeometry(radius * 0.99, 32, 32),
         createWaterMaterial({ envMap: scene.environment || null })
       );
-      scene.add(this.water);
+      this.group.add(this.water);
       if (this.debugView) {
-        this.debugView.addToScene(scene);
+        this.debugView.addToScene(this.group);
         this.debugView.group.visible = false;
       }
       if (this.layerView) {
-        this.layerView.addToScene(scene);
+        this.layerView.addToScene(this.group);
         this.layerView.group.visible = false;
       }
       this.showDebug = false;
@@ -154,6 +157,14 @@ export default class PlanetManager {
 
   setDayNightCycleEnabled(enabled) {
     this.enableDayNight = enabled;
+  }
+
+  setScale(scale) {
+    this.scale = scale;
+    this.group.scale.set(scale, scale, scale);
+    for (const chunk of this.chunks) {
+      chunk.setScale(scale);
+    }
   }
 
   update(camera) {


### PR DESCRIPTION
## Summary
- add UI slider for planet scale and a ruler toggle
- show axes and grid helpers in scene
- allow dynamic scaling via `PlanetManager.setScale` and `FaceChunk.setScale`
- mention new controls in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68594e77359083268edd85663c4ac11c