### PR TITLE
Fix layer controls by using CPU heightmap

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ npm run build
 
 Move the sliders in the UI to tweak noise parameters. Click **Rebuild** to regenerate planet chunks. A progress bar updates in real time while geometry is built in Web Workers. Chunks rebuild in parallel for faster feedback. Status messages below the bar show the current subtask in the format `Rebuild -> face (50%)`.
 
-When a WebGL2 renderer is available, set `useGPU` to enable compute shader based height generation. The code automatically falls back to a deterministic CPU implementation when GPU support is missing.
+When a WebGL2 renderer is available, you can set `useGPU` to `true` to enable compute shader based height generation. This mode currently only provides the base noise layer, so the layer checkboxes in the UI will have no effect. The demo defaults to CPU generation so that all layers can be toggled.
 
 Tests can be run with:
 

--- a/main.js
+++ b/main.js
@@ -22,7 +22,9 @@ const grid = new THREE.GridHelper(4, 4);
 scene.add(axes);
 scene.add(grid);
 
-const planet = new PlanetManager(scene, 1, true, true, renderer);
+// Use CPU-based height generation by default so all layers work
+// Set the third argument to `true` to enable GPU compute shaders
+const planet = new PlanetManager(scene, 1, false, true, renderer);
 
 const amp = document.getElementById('amp');
 const freq = document.getElementById('freq');


### PR DESCRIPTION
## Summary
- default to CPU terrain generation so layer toggles work
- document GPU mode limitations in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68596d3093488326a9ffd4afdcf261fc