### PR TITLE
Implement OBJ export tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Additional controls let you scale the entire planet and toggle on-screen rulers 
 
 ## Documentation
 
-See [`PROJECT.md`](PROJECT.md) for an overview of the architecture and future plans. Modifier screenshots are located in [`docs/screenshots`](docs/screenshots). Details about the rocky layer are in [`docs/RockyLayer.md`](docs/RockyLayer.md). Information about the tectonic plate system can be found in [`docs/TectonicPlates.md`](docs/TectonicPlates.md).
+See [`PROJECT.md`](PROJECT.md) for an overview of the architecture and future plans. Modifier screenshots are located in [`docs/screenshots`](docs/screenshots). Details about the rocky layer are in [`docs/RockyLayer.md`](docs/RockyLayer.md). Information about the tectonic plate system can be found in [`docs/TectonicPlates.md`](docs/TectonicPlates.md). See [`docs/Exporting.md`](docs/Exporting.md) for details on exporting chunk geometry.
 
 ## Terrain Layers
 

--- a/docs/Exporting.md
+++ b/docs/Exporting.md
@@ -1,0 +1,15 @@
+# Exporting Planet Geometry
+
+You can export the geometry of a face chunk using the built-in OBJ exporter. This allows inspection or further processing of the generated terrain in external tools.
+
+```
+import PlanetManager from './src/PlanetManager.js';
+import { exportChunkOBJ } from './src/utils/ExportUtils.js';
+
+const manager = new PlanetManager(scene);
+const chunk = manager.chunks[0];
+const objText = exportChunkOBJ(chunk);
+console.log(objText);
+```
+
+The returned string follows the standard OBJ format and can be saved to a file or downloaded in the browser.

--- a/src/utils/ExportUtils.js
+++ b/src/utils/ExportUtils.js
@@ -1,0 +1,9 @@
+import { OBJExporter } from 'three/examples/jsm/exporters/OBJExporter.js';
+
+export function exportChunkOBJ(chunk) {
+  if (!chunk.mesh) {
+    chunk.createMesh();
+  }
+  const exporter = new OBJExporter();
+  return exporter.parse(chunk.mesh);
+}

--- a/test/deterministicHeight.js
+++ b/test/deterministicHeight.js
@@ -34,3 +34,4 @@ import './plateTectonics.js';
 import './rockyLayer.js';
 import './gpuHeight.js';
 import './plateModifier.js';
+import './exportTools.js';

--- a/test/exportTools.js
+++ b/test/exportTools.js
@@ -1,0 +1,12 @@
+import assert from 'assert';
+import FaceChunk from '../src/FaceChunk.js';
+import GeometryBuilder from '../src/GeometryBuilder.js';
+import { exportChunkOBJ } from '../src/utils/ExportUtils.js';
+
+const builder = new GeometryBuilder({ getHeight: () => 0 }, 1);
+const chunk = new FaceChunk('px', builder, 2);
+chunk.createMesh();
+const obj = exportChunkOBJ(chunk);
+
+assert(obj.includes('\nv '));
+console.log('Export chunk OBJ test passed.');


### PR DESCRIPTION
## Summary
- add `exportChunkOBJ` utility for exporting chunks
- document export usage
- test OBJ export via new unit test
- link new doc from README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68597b05a0cc832687ad1e45ed5c6869