### PR TITLE
Add GLTF export support

### DIFF
--- a/docs/Exporting.md
+++ b/docs/Exporting.md
@@ -1,6 +1,6 @@
 # Exporting Planet Geometry
 
-You can export the geometry of a face chunk using the built-in OBJ exporter. This allows inspection or further processing of the generated terrain in external tools.
+You can export the geometry of a face chunk using the built-in OBJ or GLTF exporters. This allows inspection or further processing of the generated terrain in external tools.
 
 ```
 import PlanetManager from './src/PlanetManager.js';
@@ -12,4 +12,13 @@ const objText = exportChunkOBJ(chunk);
 console.log(objText);
 ```
 
-The returned string follows the standard OBJ format and can be saved to a file or downloaded in the browser.
+To export as [GLTF](https://github.com/KhronosGroup/glTF) instead:
+
+```
+import { exportChunkGLTF } from './src/utils/ExportUtils.js';
+
+const gltfText = await exportChunkGLTF(chunk);
+console.log(gltfText);
+```
+
+The returned string can be saved to a file or downloaded in the browser. For GLTF exports the text represents the glTF JSON document.

--- a/src/utils/ExportUtils.js
+++ b/src/utils/ExportUtils.js
@@ -1,4 +1,5 @@
 import { OBJExporter } from 'three/examples/jsm/exporters/OBJExporter.js';
+import { GLTFExporter } from 'three/examples/jsm/exporters/GLTFExporter.js';
 
 export function exportChunkOBJ(chunk) {
   if (!chunk.mesh) {
@@ -6,4 +7,46 @@ export function exportChunkOBJ(chunk) {
   }
   const exporter = new OBJExporter();
   return exporter.parse(chunk.mesh);
+}
+
+export function exportChunkGLTF(chunk, options = { binary: false }) {
+  if (!chunk.mesh) {
+    chunk.createMesh();
+  }
+  if (typeof FileReader === 'undefined') {
+    global.FileReader = class {
+      constructor() {
+        this.onloadend = null;
+        this.result = null;
+      }
+      readAsDataURL(blob) {
+        blob.arrayBuffer().then(buf => {
+          const b64 = Buffer.from(buf).toString('base64');
+          this.result = `data:${blob.type || 'application/octet-stream'};base64,${b64}`;
+          if (this.onloadend) this.onloadend();
+        });
+      }
+      readAsArrayBuffer(blob) {
+        blob.arrayBuffer().then(buf => {
+          this.result = buf;
+          if (this.onloadend) this.onloadend();
+        });
+      }
+    };
+  }
+  const exporter = new GLTFExporter();
+  return new Promise((resolve, reject) => {
+    exporter.parse(
+      chunk.mesh,
+      (result) => {
+        if (options.binary && result instanceof ArrayBuffer) {
+          resolve(result);
+        } else {
+          resolve(typeof result === 'string' ? result : JSON.stringify(result));
+        }
+      },
+      (error) => reject(error),
+      options
+    );
+  });
 }

--- a/test/exportTools.js
+++ b/test/exportTools.js
@@ -1,7 +1,7 @@
 import assert from 'assert';
 import FaceChunk from '../src/FaceChunk.js';
 import GeometryBuilder from '../src/GeometryBuilder.js';
-import { exportChunkOBJ } from '../src/utils/ExportUtils.js';
+import { exportChunkOBJ, exportChunkGLTF } from '../src/utils/ExportUtils.js';
 
 const builder = new GeometryBuilder({ getHeight: () => 0 }, 1);
 const chunk = new FaceChunk('px', builder, 2);
@@ -10,3 +10,7 @@ const obj = exportChunkOBJ(chunk);
 
 assert(obj.includes('\nv '));
 console.log('Export chunk OBJ test passed.');
+
+const gltf = await exportChunkGLTF(chunk);
+assert(gltf.includes('"asset"'));
+console.log('Export chunk GLTF test passed.');


### PR DESCRIPTION
## Summary
- extend ExportUtils with `exportChunkGLTF`
- document GLTF export usage
- test exporting a chunk to GLTF

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68597d11f258832680c6ba53cb9f0b23