### PR TITLE
Add layer influence API with docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ for realistic geometry. The main layers are:
 
 Adjusting these layers in the UI or code allows experimentation while keeping
 terrain generation stable.
+You can also measure how much a single layer contributes to the final height
+with `pipeline.getLayerInfluence(id, x, y, z)`. See
+[`docs/LayerInfluence.md`](docs/LayerInfluence.md) for details.
 
 ### Customizing Tectonic Plates
 

--- a/docs/LayerInfluence.md
+++ b/docs/LayerInfluence.md
@@ -1,0 +1,13 @@
+# Layer Influence
+
+`LayerPipeline` exposes a helper for measuring how much a single layer affects the final height.
+
+```js
+import LayerPipeline from './src/LayerPipeline.js';
+
+const pipeline = new LayerPipeline(1234);
+const influence = pipeline.getLayerInfluence('tectonics', 0.1, 0.2, 0.3);
+console.log(influence);
+```
+
+`getLayerInfluence(id, x, y, z)` temporarily disables the chosen layer, computes the terrain height, then re-enables it to measure the difference. Higher absolute values indicate that the layer strongly shapes the terrain at that point.

--- a/src/LayerPipeline.js
+++ b/src/LayerPipeline.js
@@ -125,6 +125,16 @@ export default class LayerPipeline {
     this.enabled.set(id, enabled);
   }
 
+  getLayerInfluence(id, x, y, z) {
+    const original = this.enabled.get(id);
+    this.enabled.set(id, false);
+    const without = this.getHeight(x, y, z);
+    this.enabled.set(id, true);
+    const withLayer = this.getHeight(x, y, z);
+    this.enabled.set(id, original);
+    return withLayer - without;
+  }
+
   setBaseNoiseParams({ amplitude, frequency, octaves, warpIntensity }) {
     if (amplitude !== undefined) this.fbm.amplitude = amplitude;
     if (frequency !== undefined) this.fbm.frequency = frequency;

--- a/test/deterministicHeight.js
+++ b/test/deterministicHeight.js
@@ -35,3 +35,4 @@ import './rockyLayer.js';
 import './gpuHeight.js';
 import './plateModifier.js';
 import './exportTools.js';
+import './layerInfluence.js';

--- a/test/layerInfluence.js
+++ b/test/layerInfluence.js
@@ -1,0 +1,18 @@
+import assert from 'assert';
+import LayerPipeline from '../src/LayerPipeline.js';
+
+const coords = [
+  [0.1, 0.2, 0.3],
+  [0.4, -0.1, 0.2],
+  [0.7, 0.3, -0.2]
+];
+
+for (const [x, y, z] of coords) {
+  const p1 = new LayerPipeline(1234);
+  const p2 = new LayerPipeline(1234);
+  const inf1 = p1.getLayerInfluence('tectonics', x, y, z);
+  const inf2 = p2.getLayerInfluence('tectonics', x, y, z);
+  assert.strictEqual(inf1, inf2);
+}
+
+console.log('Layer influence test passed.');


### PR DESCRIPTION
## Summary
- implement `getLayerInfluence` in `LayerPipeline`
- document usage in new `LayerInfluence.md`
- mention feature in README
- test layer influence output

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68597d60e3148326b6b83ac5da51600e