### PR TITLE
Fix sliders not responding when opening index.html directly

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ npm start
 ```
 
 The app will be available at `http://localhost:5173`.
+You can also open `index.html` directly from the filesystem as the main script
+now uses a relative path, but running the dev server is recommended for hot
+reloading and module resolution.
 
 To produce an optimized build run:
 

--- a/index.html
+++ b/index.html
@@ -108,7 +108,8 @@
     <div id="status"></div>
   </div>
 
-  <script type="module" src="/main.js"></script>
+  <!-- Use relative path so the demo works when opened directly -->
+  <script type="module" src="./main.js"></script>
 
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { OrbitControls } from 'three/examples/jsm/controls/OrbitControls.js';
-import PlanetManager from '/src/PlanetManager.js';
+// Use a relative path so loading index.html directly works without a dev server
+import PlanetManager from './src/PlanetManager.js';
 
 const renderer = new THREE.WebGLRenderer({ antialias: true });
 renderer.setSize(window.innerWidth, window.innerHeight);


### PR DESCRIPTION
## Summary
- reference main script with a relative path
- update PlanetManager import to use a relative path
- document that `index.html` can be opened directly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68597eb6b21c8326befe5b106947f40c